### PR TITLE
Integrate results from application-level checkers

### DIFF
--- a/docs/application-checker.md
+++ b/docs/application-checker.md
@@ -33,7 +33,7 @@ The first type of checkers is for data. Checkers of this type should implement t
 ```typescript
 export interface AppStateCheckLogic {
     probeStateCheck(kvState: KeyValueState): Promise<boolean>;
-    performStateCheck(kvState: KeyValueState): Promise<void>;
+    performStateCheck(kvState: KeyValueState, resultSet: ResultSet): Promise<void>;
 }
 ```
 

--- a/src/bcverifier.ts
+++ b/src/bcverifier.ts
@@ -115,7 +115,7 @@ export class BCVerifier {
                 const stateSet = await kvProvider.getKeyValueState(lastKeyValueTx);
                 for (const v of appStateCheckers) {
                     if (await v.probeStateCheck(stateSet)) {
-                        await v.performStateCheck(stateSet);
+                        await v.performStateCheck(stateSet, this.resultSet);
                     }
                 }
             } catch (e) {
@@ -130,7 +130,7 @@ export class BCVerifier {
                     const appTx = kvProvider.getAppTransaction(tx.getTransactionID());
                     for (const v of appTxCheckers) {
                         if (await v.probeTransactionCheck(appTx)) {
-                            await v.performTransactionCheck(appTx);
+                            await v.performTransactionCheck(appTx, this.resultSet);
                         }
                     }
                 }

--- a/src/check/index.ts
+++ b/src/check/index.ts
@@ -28,10 +28,10 @@ export interface TransactionCheckPlugin {
 
 export interface AppStateCheckLogic {
     probeStateCheck(kvState: KeyValueState): Promise<boolean>;
-    performStateCheck(kvState: KeyValueState): Promise<void>;
+    performStateCheck(kvState: KeyValueState, resultSet: ResultSet): Promise<void>;
 }
 
 export interface AppTransactionCheckLogic {
     probeTransactionCheck(tx: AppTransaction): Promise<boolean>;
-    performTransactionCheck(tx: AppTransaction): Promise<void>;
+    performTransactionCheck(tx: AppTransaction, resultSet: ResultSet): Promise<void>;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,6 +95,7 @@ async function start(): Promise<number> {
     console.log("  Checks performed: %d (%d blocks)", resultSummary.blockChecks.total, resultSummary.blocks.total);
     console.log("  Checks passed:    %d (%d blocks)", resultSummary.blockChecks.passed, resultSummary.blocks.passed);
     console.log("  Checks failed:    %d (%d blocks)", resultSummary.blockChecks.failed, resultSummary.blocks.failed);
+    console.log("  Checks skipped:   %d            ", resultSummary.blockChecks.skipped);
     console.log("");
     console.log("Transactions:");
     console.log("  Checks performed: %d (%d transactions)",
@@ -103,6 +104,7 @@ async function start(): Promise<number> {
                 resultSummary.transactionChecks.passed, resultSummary.transactions.passed);
     console.log("  Checks failed:    %d (%d transactions)",
                 resultSummary.transactionChecks.failed, resultSummary.transactions.failed);
+    console.log("  Checks skipped:   %d                  ", resultSummary.transactionChecks.skipped);
     console.log("");
 
     if (resultSummary.blockChecks.failed === 0 && resultSummary.transactionChecks.failed === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,7 @@ async function start(): Promise<number> {
     console.log("  Checks performed: %d (%d transactions)",
                 resultSummary.transactionChecks.total, resultSummary.transactions.total);
     console.log("  Checks passed:    %d (%d transactions)",
-                resultSummary.transactionChecks.total, resultSummary.transactions.total);
+                resultSummary.transactionChecks.passed, resultSummary.transactions.passed);
     console.log("  Checks failed:    %d (%d transactions)",
                 resultSummary.transactionChecks.failed, resultSummary.transactions.failed);
     console.log("");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,8 +106,15 @@ async function start(): Promise<number> {
                 resultSummary.transactionChecks.failed, resultSummary.transactions.failed);
     console.log("  Checks skipped:   %d                  ", resultSummary.transactionChecks.skipped);
     console.log("");
+    console.log("States:");
+    console.log("  Checks performed: %d", resultSummary.stateChecks.total);
+    console.log("  Checks passed:    %d", resultSummary.stateChecks.passed);
+    console.log("  Checks failed:    %d", resultSummary.stateChecks.failed);
+    console.log("  Checks skipped:   %d", resultSummary.stateChecks.skipped);
+    console.log("");
 
-    if (resultSummary.blockChecks.failed === 0 && resultSummary.transactionChecks.failed === 0) {
+    if (resultSummary.blockChecks.failed === 0 && resultSummary.transactionChecks.failed === 0 &&
+        resultSummary.stateChecks.failed === 0) {
         console.log("All checks finished successfully.");
         return 0;
     } else {

--- a/src/common.ts
+++ b/src/common.ts
@@ -56,6 +56,10 @@ export interface TransactionResult {
     results: CheckResult[];
 }
 
+export interface StateResult {
+    results: CheckResult[];
+}
+
 export interface VerificationResult {
     blocks: BlockResult[];
     transactions: TransactionResult[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export { BCVerifier } from "./bcverifier";
 export * from "./check";
 export * from "./common";
 export * from "./data/fabric";
+export * from "./result-set";

--- a/src/result-set.ts
+++ b/src/result-set.ts
@@ -5,7 +5,7 @@
  */
 
 import { BCVerifierError, Block, BlockResult, CheckResult,
-         ResultCode, ResultOperand, ResultPredicate, Transaction, TransactionResult } from "./common";
+         ResultCode, ResultOperand, ResultPredicate, StateResult, Transaction, TransactionResult } from "./common";
 
 function evaluate(predicate: ResultPredicate, values: ResultOperand[]): boolean {
     const v = values[0];
@@ -197,6 +197,7 @@ export type CheckSummary = {
     blockChecks: CheckCount;
     transactions: CheckCount;
     transactionChecks: CheckCount;
+    stateChecks: CheckCount;
 
     blockRange: { start: number, end: number };
 };
@@ -204,10 +205,14 @@ export type CheckSummary = {
 export class ResultSet {
     private blocks: { [blockNumber: number]: BlockResult };
     private transactions: { [transactionID: string]: TransactionResult };
+    private state: StateResult;
 
     constructor() {
         this.blocks = {};
         this.transactions = {};
+        this.state = {
+            results: []
+        };
     }
 
     public getBlockResults(): BlockResult[] {
@@ -266,6 +271,10 @@ export class ResultSet {
         t.results.push(result);
     }
 
+    public pushStateResult(result: CheckResult): void {
+        this.state.results.push(result);
+    }
+
     public getSummary(): CheckSummary {
         let minBlock: number | null = null;
         let maxBlock: number | null = null;
@@ -317,12 +326,14 @@ export class ResultSet {
         if (maxBlock == null) {
             maxBlock = -1;
         }
+        const stateCount = this.countChecks(this.state.results);
 
         return {
             blocks: blockCount,
             blockChecks: blockChecksCount,
             transactions: txCount,
             transactionChecks: txChecksCount,
+            stateChecks: stateCount,
 
             blockRange: { start: minBlock, end: maxBlock }
         };

--- a/src/samples/fabcar.ts
+++ b/src/samples/fabcar.ts
@@ -7,8 +7,8 @@
 // tslint:disable:no-console
 
 import { AppTransaction, AppTransactionCheckLogic, CheckPlugin,
-         FabricFunctionInfo, FabricTransaction } from "..";
-import { BCVerifierNotFound } from "../common";
+         FabricFunctionInfo, FabricTransaction, ResultSet } from "..";
+import { BCVerifierNotFound, ResultCode, ResultPredicate } from "../common";
 
 export default class FabCarChecker extends CheckPlugin implements AppTransactionCheckLogic {
     public async probeTransactionCheck(appTx: AppTransaction): Promise<boolean> {
@@ -30,7 +30,7 @@ export default class FabCarChecker extends CheckPlugin implements AppTransaction
         return true;
     }
 
-    public async performTransactionCheck(appTx: AppTransaction): Promise<void> {
+    public async performTransactionCheck(appTx: AppTransaction, resultSet: ResultSet): Promise<void> {
         const fabricTx = appTx.getTransaction() as FabricTransaction;
         const action = fabricTx.getActions()[0];
         const func = action.getFunction() as FabricFunctionInfo;
@@ -38,25 +38,72 @@ export default class FabCarChecker extends CheckPlugin implements AppTransaction
 
         if (funcNameStr === "createCar") {
             // createCar(key, make, model, color, owner)
+            const CHECKER_ID = "fabcar-createCar-checker";
+
             const writeSet = fabricTx.getWriteSet();
             const values = writeSet.filter((pair) => pair.key.toString().startsWith("fabcar\0"));
 
             if (values.length !== 1) {
+                resultSet.pushTransactionResult(fabricTx, {
+                    checkerID: CHECKER_ID,
+                    result: ResultCode.ERROR,
+                    predicate: ResultPredicate.EQ,
+                    operands: [ { name: fabricTx.toString() + ".WriteSet.length", value: values.length },
+                                { name: "1", value: 1 } ]
+                });
                 console.error("ERROR: CreateCar should not write to more than one key");
                 console.debug("  Tx %s writes to keys %s", fabricTx.getTransactionID(),
                               values.map((k) => k.key.toString()).join(","));
             } else {
+                resultSet.pushTransactionResult(fabricTx, {
+                    checkerID: CHECKER_ID,
+                    result: ResultCode.OK,
+                    predicate: ResultPredicate.EQ,
+                    operands: [ { name: fabricTx.toString() + ".WriteSet.length", value: values.length },
+                                { name: "1", value: 1 } ]
+                });
+
                 const v = values[0];
                 if (v.key.toString() !== "fabcar\0" + func.args[0].toString()) {
+                    resultSet.pushTransactionResult(fabricTx, {
+                        checkerID: CHECKER_ID,
+                        result: ResultCode.ERROR,
+                        predicate: ResultPredicate.EQ,
+                        operands: [ { name: fabricTx.toString() + ".WriteSet[0].key", value: v.key.toString() },
+                                    { name: "fabcar\0" + func.args[0].toString(),
+                                      value: "fabcar\0" + func.args[0].toString() } ]
+                    });
                     console.error("ERROR: CreateCar should not write to other key than %s", func.args[0].toString());
                 } else {
+                    resultSet.pushTransactionResult(fabricTx, {
+                        checkerID: CHECKER_ID,
+                        result: ResultCode.OK,
+                        predicate: ResultPredicate.EQ,
+                        operands: [ { name: fabricTx.toString() + ".WriteSet[0].key", value: v.key.toString() },
+                                    { name: "fabcar\0" + func.args[0].toString(),
+                                      value: "fabcar\0" + func.args[0].toString() } ]
+                    });
+
                     const state = appTx.getState();
 
                     try {
                         state.getValue(v.key);
                         console.error("ERROR: CreateCar should not overwrite the existing car");
-                    } catch (e) {
+
+                        resultSet.pushTransactionResult(fabricTx, {
+                            checkerID: CHECKER_ID,
+                            result: ResultCode.ERROR,
+                            predicate: ResultPredicate.INVOKE,
+                            operands: [ { name: "getValue(" + v.key + ")", value: v.key.toString() } ]
+                        });
+                } catch (e) {
                         if (e instanceof BCVerifierNotFound) {
+                            resultSet.pushTransactionResult(fabricTx, {
+                                checkerID: CHECKER_ID,
+                                result: ResultCode.OK,
+                                predicate: ResultPredicate.INVOKE,
+                                operands: [ { name: "getValue(" + v.key + ")", value: v.key.toString() } ]
+                            });
                             console.log("INFO: Transaction %s: createCar is ok", fabricTx.getTransactionID());
                         } else {
                             console.error("ERROR: Error while checking: %s", e);
@@ -66,27 +113,102 @@ export default class FabCarChecker extends CheckPlugin implements AppTransaction
             }
         } else if (funcNameStr === "changeCarOwner") {
             // changeCarOwner(key, newOwner)
+            const CHECKER_ID = "fabcar-changeCarOwner-checker";
+
             const writeSet = fabricTx.getWriteSet();
             const values = writeSet.filter((pair) => pair.key.toString().startsWith("fabcar\0"));
 
             if (values.length !== 1) {
+                resultSet.pushTransactionResult(fabricTx, {
+                    checkerID: CHECKER_ID,
+                    result: ResultCode.ERROR,
+                    predicate: ResultPredicate.EQ,
+                    operands: [ { name: fabricTx.toString() + ".WriteSet.length", value: values.length },
+                                { name: "1", value: 1 } ]
+                });
+
                 console.error("ERROR: changeCarOwner should not write to more than one key");
                 console.debug("  Tx %s writes to keys %s", fabricTx.getTransactionID(),
                               values.map((k) => k.key.toString()).join(","));
             } else {
+                resultSet.pushTransactionResult(fabricTx, {
+                    checkerID: CHECKER_ID,
+                    result: ResultCode.OK,
+                    predicate: ResultPredicate.EQ,
+                    operands: [ { name: fabricTx.toString() + ".WriteSet.length", value: values.length },
+                                { name: "1", value: 1 } ]
+                });
+
                 const v = values[0];
                 if (v.key.toString() !== "fabcar\0" + func.args[0].toString()) {
+                    resultSet.pushTransactionResult(fabricTx, {
+                        checkerID: CHECKER_ID,
+                        result: ResultCode.ERROR,
+                        predicate: ResultPredicate.EQ,
+                        operands: [ { name: fabricTx.toString() + ".WriteSet[0].key", value: v.key.toString() },
+                                    { name: "fabcar\0" + func.args[0].toString(),
+                                      value: "fabcar\0" + func.args[0].toString() } ]
+                    });
+
                     console.error("ERROR: changeCarOwner should not write other cars than specified.");
                     console.debug("  Tx %s writes to key %s", fabricTx.getTransactionID(), v.key.toString());
-                } else if (v.isDelete === true) {
-                    console.error("ERROR: changeCarOwner should not delete the key");
                 } else {
-                    const newCar = JSON.parse(v.value.toString());
+                    resultSet.pushTransactionResult(fabricTx, {
+                        checkerID: CHECKER_ID,
+                        result: ResultCode.OK,
+                        predicate: ResultPredicate.EQ,
+                        operands: [ { name: fabricTx.toString() + ".WriteSet[0].key", value: v.key.toString() },
+                                    { name: "fabcar\0" + func.args[0].toString(),
+                                      value: "fabcar\0" + func.args[0].toString() } ]
+                    });
 
-                    if (newCar.owner !== func.args[1].toString()) {
-                        console.error("ERROR: changeCarOwner changes the owner to another person: %s", newCar.owner);
+                    if (v.isDelete === true) {
+                        resultSet.pushTransactionResult(fabricTx, {
+                            checkerID: CHECKER_ID,
+                            result: ResultCode.ERROR,
+                            predicate: ResultPredicate.EQ,
+                            operands: [ { name: fabricTx.toString() + ".WriteSet[0].isDelete", value: v.isDelete },
+                                        { name: "true", value: true } ]
+                        });
+
+                        console.error("ERROR: changeCarOwner should not delete the key");
                     } else {
-                        console.log("INFO: Transaction %s: changeCarOwner is ok", fabricTx.getTransactionID());
+                        resultSet.pushTransactionResult(fabricTx, {
+                            checkerID: CHECKER_ID,
+                            result: ResultCode.OK,
+                            predicate: ResultPredicate.EQ,
+                            operands: [ { name: fabricTx.toString() + ".WriteSet[0].isDelete", value: v.isDelete },
+                                        { name: "true", value: true } ]
+                        });
+
+                        const newCar = JSON.parse(v.value.toString());
+
+                        if (newCar.owner !== func.args[1].toString()) {
+                            resultSet.pushTransactionResult(fabricTx, {
+                                checkerID: CHECKER_ID,
+                                result: ResultCode.ERROR,
+                                predicate: ResultPredicate.EQ,
+                                operands: [ { name: fabricTx.toString() + ".WriteSet[0].value.owner",
+                                              value: v.key.toString() },
+                                            { name: func.args[1].toString(),
+                                              value: func.args[1].toString() } ]
+                            });
+
+                            console.error("ERROR: changeCarOwner changes the owner to another person: %s",
+                                          newCar.owner);
+                        } else {
+                            resultSet.pushTransactionResult(fabricTx, {
+                                checkerID: CHECKER_ID,
+                                result: ResultCode.OK,
+                                predicate: ResultPredicate.EQ,
+                                operands: [ { name: fabricTx.toString() + ".WriteSet[0].value.owner",
+                                              value: v.key.toString() },
+                                            { name: func.args[1].toString(),
+                                              value: func.args[1].toString() } ]
+                            });
+
+                            console.log("INFO: Transaction %s: changeCarOwner is ok", fabricTx.getTransactionID());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR adds interface for application-level checkers to report their results.

With this interface, the results are integrated to those from other checkers (i.e. block and transaction integrity checks)