### PR TITLE
Ver 0.2.2: Add "fabric-query2" plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ Runs verification against a Hyperledger Fabric ledger file `/tmp/block/blockfile
 
 ## Network plugins
 
-| Name           | Supported Platform          | Description                         | Config value (`-c` option)             |
-|----------------|-----------------------------|-------------------------------------|----------------------------------------|
-| `fabric-block` | Hyperledger Fabric v1.4/2.2 | Verify a ledger file and private DB | Path to the ledger file or config JSON |
-| `fabric-query` | Hyperledger Fabric v1.4     | Verify blocks by querying to a peer | Path to the query config file          |
+| Name            | Supported Platform          | Description                                | Config value (`-c` option)             |
+|-----------------|-----------------------------|--------------------------------------------|----------------------------------------|
+| `fabric-block`  | Hyperledger Fabric v1.4/2.2 | Verify a ledger file and private DB        | Path to the ledger file or config JSON |
+| `fabric-query`  | Hyperledger Fabric v1.4     | Verify blocks by querying to a peer        | Path to the query config file          |
+| `fabric-query2` | Hyperledger Fabric v2.2     | Verify blocks by querying to a peer (v2.x) | Path to the query config file (v2)     |
 
 ### fabric-block
 
@@ -98,6 +99,45 @@ Example:
 *Limitation:* The ledger may be divided to multiple files when it becomes huge, but the plugin currently
 only supports a single file. You may try to check the divided files by concatenating the ledger files.
 Even if the directory is specified with the JSON, the plugin uses only the first file(`blockfile_000000`).
+
+### fabric-query2
+
+This plugin checks blocks by obtaining them calling `qscc` system chaincode in a peer.
+As this plugin uses v2.x of Fabric SDK, this only supports v2.x peers. For v1.4 peers, the `fabric-query` plugin should be used.
+
+The configuration value for the plugin should be the file name to a configuration JSON.
+Note that the structure of the JSON is far different from that for `fabric-query`.
+
+The format is shown below:
+
+| Key name                       | Type    | Description                                                         |
+|--------------------------------|---------|---------------------------------------------------------------------|
+| `peer.url`                     | string  | URL to a peer (e.g. `grpcs://peer1.org1.example.com:7051`)          |
+| `peer.mspID`                   | string  | MSP ID for the organization which the peer belongs to               |
+| `peer.tlsCACertFile`           | string  | CA certificate for TLS with the peer (Required when TLS is enabled) |
+| `channel`                      | string  | Channel name                                                        |
+| `client.certFile`              | string  | Certificate for the client identity to use to connect to the peer   |
+| `client.keyFile`               | string  | Private key for the client identity to use to connect to the peer   |
+| `client.mspID`                 | string  | MSP ID for the client identity                                      |
+| `client.mutualTLS.certFile`    | string  | Client certificate (Required when mutual TLS is enabled)            |
+| `client.mutualTLS.keyFile`     | string  | Client private key (Required when mutual TLS is enabled)            |
+
+Example:
+```
+{
+  "peer": {
+    "url": "grpcs://localhost:7051",
+    "mspID": "Org1MSP",
+    "tlsCACertFile": "/opt/gopath/src/github.com/hyperledger/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/tlscacerts/tls-localhost-7054-ca-org1.pem"
+  },
+  "channel": "mychannel",
+  "client": {
+    "certFile": "/opt/gopath/src/github.com/hyperledger/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/cert.pem",
+    "keyFile": "/opt/gopath/src/github.com/hyperledger/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/e488b2baef3f8121f9122140bd937c7708336f185e1668d66bbfbf5157379e27_sk",
+    "mspID": "Org1MSP"
+  }
+}
+```
 
 ### fabric-query
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ The goal of this tool is to verify the integrity of blockchain blocks and transa
 
 ## Install
 
-As the tool is written in TypeScript, you need to compile it before execution.
+As the tool is written in TypeScript, you need to compile it before execution (automatically done after `npm install` is executed).
 
 ```
 $ git clone https://github.com/shimos/bcverifier
 $ npm install
-$ npm run build
 ```
+
+You can also compile manually by `npm run build`.
 
 ## Usage
 
@@ -258,6 +259,10 @@ For detail, please refer to [the application checker reference](docs/application
   - Multiple ledger files for Hyperledger Fabric
 
 ## Changes
+
+### v0.2.2 (Oct. 8, 2020)
+
+- Add "fabric-query2" plugin to support querying blocks from v2.x peers
 
 ### v0.2.1 (Oct. 1, 2020)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcverifier",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Blockchain Verifier",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
       "jsx",
       "json",
       "node"
-    ]
+    ],
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "tsconfig.test.json"
+      }
+    }
   }
 }

--- a/src/bcverifier.ts
+++ b/src/bcverifier.ts
@@ -15,7 +15,8 @@ type PluginInfo = { pluginName: string, moduleName: string };
 
 const networkPlugins: PluginInfo[] = [
     { pluginName: "fabric-block", moduleName: "./network/fabric-block" },
-    { pluginName: "fabric-query", moduleName: "./network/fabric-query" }
+    { pluginName: "fabric-query", moduleName: "./network/fabric-query" },
+    { pluginName: "fabric-query2", moduleName: "./network/fabric-query2" }
 ];
 const blockVerifiers: PluginInfo[] = [
     { pluginName: "generic-block", moduleName: "./check/block-integrity" },

--- a/src/network/fabric-query2.test.ts
+++ b/src/network/fabric-query2.test.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2020 Hitachi America, Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Channel, Client, Endorser, Endpoint, IdentityContext, Query, User } from "fabric-common";
+import { common } from "fabric-protos";
+import fs from "fs";
+import path from "path";
+import { BCVerifierError } from "../common";
+import { FabricBlock } from "../data/fabric";
+import { DataModelType } from "../network-plugin";
+import FabricQuery2Plugin, { FabricQuery2PluginConfig, FabricQuery2Source } from "./fabric-query2";
+
+jest.mock("fabric-common");
+jest.mock("../data/fabric");
+
+const testDataDir = path.join(__dirname, "..", "..", "test", "fabric-query2");
+const configFile = path.join(testDataDir, "config.json");
+
+// Dummy objects
+const queryObj = new Query("cc", new Channel("ch", new Client("client")));
+const endorserObj = new Endorser("cc", new Client("client"), "msp");
+
+const channelObj = new Channel("ch", new Client("client"));
+const identityContextObj = new IdentityContext(new User("a"), new Client("client"));
+
+(channelObj.newQuery as jest.Mock).mockImplementation(() => queryObj);
+const newChannel = jest.fn().mockImplementation(() => channelObj);
+const newEndpoint = jest.fn().mockImplementation(() => new Endpoint({}));
+(Client.newClient as jest.Mock).mockImplementation(() => ({
+    newChannel: newChannel,
+    newIdentityContext: jest.fn().mockImplementation(() => identityContextObj),
+    newEndorser: () => endorserObj,
+    newEndpoint: newEndpoint
+}));
+
+describe("FabricQuery2Source", () => {
+    const config: FabricQuery2PluginConfig = JSON.parse(fs.readFileSync(configFile).toString());
+    describe("constructor", () => {
+        test("creates a FabricQuery2Source instance", () => {
+            (Client.newClient as jest.Mock).mockClear();
+            (newChannel as jest.Mock).mockClear();
+            (channelObj.newQuery as jest.Mock).mockClear();
+            (User.createUser as jest.Mock).mockClear();
+
+            const _source = new FabricQuery2Source(config, config.peer);
+
+            expect(Client.newClient).toBeCalledTimes(1);
+            expect(newChannel).toBeCalledTimes(1);
+            expect(newChannel).toBeCalledWith("test-channel");
+            expect(channelObj.newQuery).toBeCalledTimes(1);
+            expect(channelObj.newQuery).toBeCalledWith("qscc");
+            expect(User.createUser).toBeCalledTimes(1);
+            expect(User.createUser).toBeCalledWith("user", "", "user-org", "user-cert.pem", "user-key.pem");
+        });
+    });
+    describe("init()", () => {
+        test("initializes a connection to peer", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+
+            (newEndpoint as jest.Mock).mockClear();
+            (endorserObj.connect as jest.Mock).mockClear();
+
+            await source.init();
+
+            expect(newEndpoint).toBeCalledWith({
+                url: "grpcs://localhost:7051",
+                pem: "org1-ca-tls.pem",
+                clientCert: "tls-user-cert.pem",
+                clientKey: "tls-user-key.pem"
+            });
+            expect(endorserObj.connect).toBeCalledTimes(1);
+        });
+    });
+    describe("getSourceID()", () => {
+        test("returns the URL as the source ID", () => {
+            const source = new FabricQuery2Source(config, config.peer);
+
+            expect(source.getSourceID()).toBe("grpcs://localhost:7051");
+        });
+    });
+    describe("getSourceOrganizationID()", () => {
+        test("returns the MSP ID as the organization ID", () => {
+            const source = new FabricQuery2Source(config, config.peer);
+
+            expect(source.getSourceOrganizationID()).toBe("org1");
+        });
+    });
+    describe("getBlock()", () => {
+        test("returns a block", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+            await source.init();
+
+            (queryObj.build as jest.Mock).mockClear();
+            (queryObj.sign as jest.Mock).mockClear();
+            (queryObj.send as jest.Mock).mockClear().mockImplementation(() => ({
+                queryResults: [
+                    Buffer.from("This is a block 1")
+                ]
+            }));
+            (FabricBlock.fromQueryBytes as jest.Mock).mockClear().mockImplementation(() => ({
+                blockNumber: 1
+            }));
+
+            const block = await source.getBlock(1);
+
+            expect(queryObj.build).toBeCalledWith(identityContextObj, {
+                fcn: "GetBlockByNumber",
+                args: ["test-channel", "1"]
+            });
+            expect(queryObj.sign).toBeCalledWith(identityContextObj);
+            expect(FabricBlock.fromQueryBytes).toBeCalledWith(Buffer.from("This is a block 1"));
+            expect(block).toStrictEqual({ blockNumber: 1 });
+        });
+
+        test("throws an error when init was not called", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+
+            await expect(source.getBlock(1)).rejects.toThrowError(BCVerifierError);
+        });
+
+        test("throws an error when qscc returns an error", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+            await source.init();
+
+            (queryObj.send as jest.Mock).mockClear().mockImplementation(() => ({
+                queryResults: [],
+                responses: [{
+                    response: {
+                        status: 500,
+                        message: "Block out of range"
+                    }
+                }]
+            }));
+
+            await expect(source.getBlock(1000)).rejects.toThrowError(BCVerifierError);
+        });
+    });
+    describe("getBlockHash()", () => {
+        test("returns a hash", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+            await source.init();
+
+            (queryObj.send as jest.Mock).mockClear().mockImplementation(() => ({
+                queryResults: [
+                    Buffer.from("This is some block")
+                ]
+            }));
+            (FabricBlock.fromQueryBytes as jest.Mock).mockClear().mockImplementation(() => ({
+                blockNumber: 2,
+                getHashValue: () => Buffer.from("ABCD")
+            }));
+
+            const hash = await source.getBlockHash(2);
+            expect(hash.toString()).toBe("ABCD");
+        });
+    });
+    describe("getBlockRange()", () => {
+        test("returns blocks", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+            await source.init();
+
+            (queryObj.send as jest.Mock).mockClear().mockImplementation(() => (
+            {
+                queryResults: [
+                    Buffer.from("This is some block")
+                ]
+            }));
+
+            let i = 3;
+            (FabricBlock.fromQueryBytes as jest.Mock).mockClear().mockImplementation(() => ({
+                blockNumber: i++,
+                getBlockNumber: function() {
+                    return this.blockNumber;
+                }
+            }));
+
+            const blocks = await source.getBlockRange(3, 7);
+
+            expect(blocks).toHaveLength(5);
+            expect(blocks[0].getBlockNumber()).toBe(3);
+            expect(blocks[2].getBlockNumber()).toBe(5);
+            expect(blocks[4].getBlockNumber()).toBe(7);
+        });
+
+        test("throws when the range is invalid", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+            await source.init();
+
+            await expect(source.getBlockRange(4, 3)).rejects.toThrowError(BCVerifierError);
+        });
+    });
+    describe("getBlockHeight()", () => {
+        test("returns the height of blocks", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+            await source.init();
+
+            (queryObj.build as jest.Mock).mockClear();
+            (queryObj.send as jest.Mock).mockClear().mockImplementation(() => (
+                {
+                    queryResults: [
+                        common.BlockchainInfo.encode({
+                            height: 120
+                        }).finish()
+                    ]
+                }));
+
+            await expect(source.getBlockHeight()).resolves.toBe(120);
+
+            expect(queryObj.build).toBeCalledWith(identityContextObj, {
+                fcn: "GetChainInfo",
+                args: ["test-channel"]
+            });
+        });
+    });
+
+    describe("findBlockByTransaction()", () => {
+        test("returns the block for the transaction", async () => {
+            const source = new FabricQuery2Source(config, config.peer);
+            await source.init();
+
+            (queryObj.build as jest.Mock).mockClear();
+            (queryObj.send as jest.Mock).mockClear().mockImplementation(() => (
+                {
+                    queryResults: [
+                        Buffer.from("This is some block")
+                    ]
+                }));
+            (FabricBlock.fromQueryBytes as jest.Mock).mockClear().mockImplementation(() => ({
+                blockNumber: 70
+            }));
+
+            await expect(source.findBlockByTransaction("a123")).resolves.toStrictEqual({
+                blockNumber: 70
+            });
+            expect(queryObj.build).toBeCalledWith(identityContextObj, {
+                fcn: "GetBlockByTxID",
+                args: ["test-channel", "a123"]
+            });
+        });
+    });
+});
+
+describe("FabricQuery2Plugin", () => {
+    describe("constructor", () => {
+        test("creates a FabricQuery2Plugin instance", () => {
+            const _plugin = new FabricQuery2Plugin(configFile);
+        });
+        test("throws when invalid config is given", () => {
+            expect(() => {
+                const _plugin = new FabricQuery2Plugin("");
+            }).toThrowError(BCVerifierError);
+        });
+        test("throws when config file does not exist", () => {
+            expect(() => {
+                const _plugin = new FabricQuery2Plugin(path.join(testDataDir, "config.non-existent.json"));
+            }).toThrowError();
+        });
+    });
+    describe("getDataModelType()", () => {
+        test("returns KeyValue", () => {
+            const plugin = new FabricQuery2Plugin(configFile);
+            expect(plugin.getDataModelType()).toBe(DataModelType.KeyValue);
+        });
+    });
+    describe("getBlockSources()", () => {
+        test("returns one data source", async () => {
+            const plugin = new FabricQuery2Plugin(configFile);
+
+            const sources = await plugin.getBlockSources();
+            expect(sources).toHaveLength(1);
+        });
+    });
+    describe("getPreferredBlockSource()", () => {
+        test("returns the first data source", async () => {
+            const plugin = new FabricQuery2Plugin(configFile);
+
+            const sources = await plugin.getBlockSources();
+            const preferred = await plugin.getPreferredBlockSource();
+
+            expect(preferred).toBe(sources[0]);
+        });
+    });
+});

--- a/src/network/fabric-query2.ts
+++ b/src/network/fabric-query2.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 Hitachi America, Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Channel, Client, ConnectOptions, Endorser, IdentityContext, Query, User } from "fabric-common";
+import { common } from "fabric-protos";
+import fs from "fs";
+import util from "util";
+
+import { BCVerifierError } from "../common";
+import { FabricBlock } from "../data/fabric";
+import { BlockSource, DataModelType, NetworkPlugin } from "../network-plugin";
+
+const QUERY_SYSTEM_CHAINCODE = "qscc";
+const FUNC_GET_BLOCK = "GetBlockByNumber";
+const FUNC_GET_BLOCK_BY_TXID = "GetBlockByTxID";
+const FUNC_GET_CHAIN_INFO = "GetChainInfo";
+
+type FabricQuery2PluginDiscoveryConfig = {
+    useDiscovery: false;
+};
+
+interface FabricQuery2PluginPeerConfig {
+    url: string;
+    mspID: string;
+    tlsCACertFile?: string;
+}
+
+export interface FabricQuery2PluginConfig {
+    peer: FabricQuery2PluginPeerConfig;
+    channel: string;
+    client: {
+        certFile: string;
+        keyFile: string;
+        mspID: string;
+        mutualTLS?: {
+            certFile: string;
+            keyFile: string;
+        }
+    };
+    config: FabricQuery2PluginDiscoveryConfig;
+}
+
+export class FabricQuery2Source implements BlockSource {
+    protected client: Client;
+    protected channel: Channel;
+    protected identity: IdentityContext;
+    protected peer: Endorser | null;
+    protected query: Query;
+
+    protected config: FabricQuery2PluginConfig;
+    protected peerConfig: FabricQuery2PluginPeerConfig;
+
+    public constructor(config: FabricQuery2PluginConfig, peer: FabricQuery2PluginPeerConfig) {
+        this.client = Client.newClient("peer");
+        this.channel = this.client.newChannel(config.channel);
+        this.peer = null;
+        this.query = this.channel.newQuery(QUERY_SYSTEM_CHAINCODE);
+        this.config = config;
+        this.peerConfig = peer;
+
+        this.identity = this.client.newIdentityContext(
+            User.createUser("user", "",
+                this.config.client.mspID,
+                fs.readFileSync(this.config.client.certFile).toString(),
+                fs.readFileSync(this.config.client.keyFile).toString()
+            ));
+    }
+
+    public async init() {
+        this.peer = this.client.newEndorser("peer1");
+
+        const opts: ConnectOptions = {
+            url: this.peerConfig.url
+        };
+        if (this.peerConfig.tlsCACertFile != null) {
+            opts.pem = fs.readFileSync(this.peerConfig.tlsCACertFile).toString();
+        }
+        if (this.config.client.mutualTLS != null) {
+            opts.clientCert = fs.readFileSync(this.config.client.mutualTLS.certFile).toString();
+            opts.clientKey = fs.readFileSync(this.config.client.mutualTLS.keyFile).toString();
+        }
+
+        await this.peer.connect(
+            this.client.newEndpoint(opts)
+        );
+    }
+
+    public getSourceID(): string {
+        return util.format("%s", this.peerConfig.url);
+    }
+    public getSourceOrganizationID(): string {
+        return this.peerConfig.mspID;
+    }
+    public async getBlock(blockNumber: number): Promise<FabricBlock> {
+        const blockBytes = await this.queryChaincode(FUNC_GET_BLOCK, this.config.channel, blockNumber.toString());
+
+        return FabricBlock.fromQueryBytes(blockBytes);
+    }
+
+    public async getBlockRange(blockStart: number, blockEnd: number): Promise<FabricBlock[]> {
+        const result: FabricBlock[] = [];
+        if (blockEnd < blockStart) {
+            throw new BCVerifierError(util.format("Block range invalid (start: %d, end %d)", blockStart, blockEnd));
+        }
+
+        let b: number;
+        for (b = blockStart; b <= blockEnd; b++) {
+            result.push(await this.getBlock(b));
+        }
+        return result;
+    }
+    public async getBlockHash(blockNumber: number): Promise<Buffer> {
+        const block = await this.getBlock(blockNumber);
+
+        return block.getHashValue();
+    }
+    public async getBlockHeight(): Promise<number> {
+        const infoBytes = await this.queryChaincode(FUNC_GET_CHAIN_INFO, this.config.channel);
+        const info = common.BlockchainInfo.decode(infoBytes);
+
+        if (typeof(info.height) === "number") {
+            return info.height;
+        } else {
+            return info.height.toNumber();
+        }
+    }
+    public async findBlockByTransaction(txID: string): Promise<FabricBlock> {
+        const block = await this.queryChaincode(FUNC_GET_BLOCK_BY_TXID, this.config.channel, txID);
+
+        return FabricBlock.fromQueryBytes(block);
+    }
+
+    protected async queryChaincode(func: string, ...args: string[]): Promise<Buffer> {
+        if (this.peer == null) {
+            throw new BCVerifierError("FabricQuery2Source not initialized");
+        }
+
+        this.query.build(this.identity, {
+            fcn: func,
+            args: args
+        });
+        this.query.sign(this.identity);
+        const response = await this.query.send({
+            targets: [this.peer]
+        });
+
+        if (response.queryResults.length < 1) {
+            throw new BCVerifierError("Peer returned error: " + response.responses[0].response.message);
+        } else {
+            return response.queryResults[0];
+        }
+    }
+}
+
+export default class FabricQuery2Plugin implements NetworkPlugin {
+    private sources: FabricQuery2Source[] | null;
+    private pluginConfig: FabricQuery2PluginConfig;
+
+    public constructor(config: string) {
+        if (config === "") {
+            throw new BCVerifierError("fabric-query2 plugin: config should be the configuration file");
+        }
+        this.pluginConfig = JSON.parse(fs.readFileSync(config).toString());
+        this.sources = null;
+    }
+
+    public getDataModelType(): DataModelType {
+        return DataModelType.KeyValue;
+    }
+
+    public async getBlockSources(): Promise<BlockSource[]> {
+        if (this.sources == null) {
+            const blockSource = new FabricQuery2Source(this.pluginConfig, this.pluginConfig.peer);
+            await blockSource.init();
+
+            this.sources = [blockSource];
+        }
+        return this.sources;
+    }
+    public async getPreferredBlockSource(): Promise<BlockSource> {
+        if (this.sources == null) {
+            await this.getBlockSources();
+        }
+        if (this.sources != null && this.sources.length > 0) {
+            return this.sources[0];
+        } else {
+            throw new BCVerifierError("FabricQuery Plugin: Cannot find any source");
+        }
+    }
+}

--- a/test/fabric-query2/config.json
+++ b/test/fabric-query2/config.json
@@ -1,0 +1,20 @@
+{
+    "peer": {
+        "url": "grpcs://localhost:7051",
+        "mspID": "org1",
+        "tlsCACertFile": "test/fabric-query2/org1-ca-tls.pem"
+    },
+    "channel": "test-channel",
+    "client": {
+        "certFile": "test/fabric-query2/user-cert.pem",
+        "keyFile": "test/fabric-query2/user-key.pem",
+        "mspID": "user-org",
+        "mutualTLS": {
+            "certFile": "test/fabric-query2/tls-user-cert.pem",
+            "keyFile": "test/fabric-query2/tls-user-key.pem"
+        }
+    },
+    "config": {
+        "useDiscovery": false
+    }
+}

--- a/test/fabric-query2/org1-ca-tls.pem
+++ b/test/fabric-query2/org1-ca-tls.pem
@@ -1,0 +1,1 @@
+org1-ca-tls.pem

--- a/test/fabric-query2/tls-user-cert.pem
+++ b/test/fabric-query2/tls-user-cert.pem
@@ -1,0 +1,1 @@
+tls-user-cert.pem

--- a/test/fabric-query2/tls-user-key.pem
+++ b/test/fabric-query2/tls-user-key.pem
@@ -1,0 +1,1 @@
+tls-user-key.pem

--- a/test/fabric-query2/user-cert.pem
+++ b/test/fabric-query2/user-cert.pem
@@ -1,0 +1,1 @@
+user-cert.pem

--- a/test/fabric-query2/user-key.pem
+++ b/test/fabric-query2/user-key.pem
@@ -1,0 +1,1 @@
+user-key.pem

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -28,8 +28,8 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": true,                   /* Report errors on unused locals. */
-    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noUnusedLocals": false,                  /* Report errors on unused locals. */
+    "noUnusedParameters": false,               /* Report errors on unused parameters. */
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
@@ -53,6 +53,5 @@
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  },
-  "exclude": ["build", "node_modules", "**/*.test.ts"]
+  }
 }


### PR DESCRIPTION
This PR introduces a new network plugin, "fabric-query2", which uses v2.2 of fabric-sdk-node to query peers.