### PR TITLE
Publish npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+/config
+/coverage
+/node_modules
+/notes
+package-lock.json
+result.json
+/sample
+/src
+/test
+tsconfig.test.json
+.vscode
+*.tgz

--- a/README.md
+++ b/README.md
@@ -15,19 +15,14 @@ The goal of this tool is to verify the integrity of blockchain blocks and transa
 
 ## Install
 
-As the tool is written in TypeScript, you need to compile it before execution (automatically done after `npm install` is executed).
-
 ```
-$ git clone https://github.com/shimos/bcverifier
-$ npm install
+$ npm install blockchain-verifier
 ```
-
-You can also compile manually by `npm run build`.
 
 ## Usage
 
 ```
-$ node ./build/cli.js -n (Network plugin) -c (Network config) -o (Result file) (Command)
+$ npx bcverifier -n (Network plugin) -c (Network config) -o (Result file) (Command)
 ```
 
 Run with `-h` for the full list of the options.
@@ -50,7 +45,7 @@ Run with `-h` for the full list of the options.
 ### Example
 
 ```
-$ node ./build/cli.js -n fabric-block -c /tmp/block/blockfile_000000 -o result.json start
+$ npx bcverifier -n fabric-block -c /tmp/block/blockfile_000000 -o result.json start
 ```
 
 Runs verification against a Hyperledger Fabric ledger file `/tmp/block/blockfile_000000` using the `fabric-block` plugin.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bcverifier",
+  "name": "blockchain-verifier",
   "version": "0.2.2",
   "description": "Blockchain Verifier",
   "main": "build/index.js",
@@ -11,7 +11,7 @@
     "build": "tsc && chmod a+x build/cli.js",
     "test": "jest --coverage",
     "lint": "tslint 'src/**/*.ts'",
-    "prepare": "npm run build"
+    "prepare": "tsc"
   },
   "author": "Taku Shimosawa <taku.shimosawa@hal.hitachi.com>",
   "license": "Apache-2.0",
@@ -57,5 +57,6 @@
         "tsConfig": "tsconfig.test.json"
       }
     }
-  }
+  },
+  "homepage": "https://github.com/hyperledger-labs/blockchain-verifier"
 }


### PR DESCRIPTION
From this version, the tool will be published to npm.
The documentation is changed to direct installation from npm accordingly.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>