### PR TITLE
Use eslint instead of tslint

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,24 @@
+---
+  root: true
+  parser: "@typescript-eslint/parser"
+  plugins:
+    - "@typescript-eslint"
+  extends:
+    - eslint:recommended
+    - plugin:@typescript-eslint/recommended
+  rules:
+    no-bitwise: error
+    no-console: error
+    object-shorthand:
+      - error
+      - never
+    sort-imports:
+      - error
+      - ignoreDeclarationSort: true
+        ignoreCase: true
+    "@typescript-eslint/explicit-module-boundary-types": off
+    "@typescript-eslint/no-explicit-any": off
+    "@typescript-eslint/no-unused-vars":
+      - error
+      - argsIgnorePattern: "^_"
+        varsIgnorePattern: "^_"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockchain-verifier",
-  "version": "0.2.2",
+  "version": "0.3.0-pre",
   "description": "Blockchain Verifier",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc && chmod a+x build/cli.js",
     "test": "jest --coverage",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "eslint src --ext .ts",
     "prepare": "tsc"
   },
   "author": "Taku Shimosawa <taku.shimosawa@hal.hitachi.com>",
@@ -20,9 +20,11 @@
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.2",
     "@types/pem": "^1.9.5",
+    "@typescript-eslint/eslint-plugin": "^4.4.1",
+    "@typescript-eslint/parser": "^4.4.1",
+    "eslint": "^7.11.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.4.1",
-    "tslint": "^5.20.1",
     "typescript": "^4.0.3"
   },
   "dependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,8 +4,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-// tslint:disable:no-console
+/* eslint-disable no-console */
 
 import commander from "commander";
 import { writeFileSync } from "fs";
@@ -23,7 +22,7 @@ function list(val: string): string[] {
     return val.split(",");
 }
 
-commander.version("v0.2.0")
+commander.version("v0.3.0")
     .description("Blockchain Verifier CLI")
     .option("-n, --network-type <type>", "Network type")
     .option("-c, --network-config <config>", "Config for network")

--- a/src/data/fabric/fabric-data.ts
+++ b/src/data/fabric/fabric-data.ts
@@ -29,13 +29,14 @@ class VarBuffer {
         let ret = 0;
         let i = 0;
 
+        // eslint-disable-next-line no-constant-condition
         while (true) {
             const value = this.buffer.readUInt8(this.offset);
             this.offset++;
 
-            // tslint:disable-next-line: no-bitwise
+            // eslint-disable-next-line no-bitwise
             ret = ret | ((value & 0x7f) << (i * 7));
-            // tslint:disable-next-line: no-bitwise
+            // eslint-disable-next-line no-bitwise
             if (!(value & 0x80)) {
                 break;
             }
@@ -55,9 +56,9 @@ function encodeOrderPreservingInt(num: number) {
     const enc: number[] = [];
     // First encode to bytes in little-endian
     while (num > 0) {
-        // tslint:disable-next-line: no-bitwise
+        // eslint-disable-next-line no-bitwise
         enc.push(num & 0xff);
-        // tslint:disable-next-line: no-bitwise
+        // eslint-disable-next-line no-bitwise
         num = num >> 8;
     }
     const szBuf = encodeVarInt(enc.length);
@@ -74,9 +75,9 @@ function encodeVarInt(num: number): Buffer {
     const enc: number[] = [];
 
     while (num > 0) {
-        // tslint:disable-next-line: no-bitwise
+        // eslint-disable-next-line no-bitwise
         enc.push(num & 0x7f);
-        // tslint:disable-next-line: no-bitwise
+        // eslint-disable-next-line no-bitwise
         num = num >> 7;
     }
     if (enc.length === 0) {
@@ -87,7 +88,7 @@ function encodeVarInt(num: number): Buffer {
     for (let i = 0; i < enc.length; i++) {
         const j = enc.length - i - 1;
         if (j !== 0) {
-            // tslint:disable-next-line: no-bitwise
+            // eslint-disable-next-line no-bitwise
             buf.writeUInt8(enc[j] | 0x80, i);
         } else {
             buf.writeUInt8(enc[j], i);

--- a/src/network/fabric-block.test.ts
+++ b/src/network/fabric-block.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Hitachi America, Ltd.
+ * Copyright 2019-2020 Hitachi America, Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,6 +20,7 @@ const testDataset: { [name: string]: string } = {
 describe("FabricBlockSource", () => {
     for (const dataName in testDataset) {
         const dataPath = testDataset[dataName];
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
         const dataConfig = require(path.join(dataPath, "config.json"));
 
         test("Create BlockSource - " + dataName, async () => {
@@ -80,6 +81,7 @@ describe("FabricBlockSource", () => {
 describe("FabricBlockPlugin", () => {
     for (const dataName in testDataset) {
         const dataPath = testDataset[dataName];
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
         const dataConfig = require(path.join(dataPath, "config.json"));
 
         // test for the first set only

--- a/src/network/fabric-block.ts
+++ b/src/network/fabric-block.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Hitachi America, Ltd.
+ * Copyright 2018-2020 Hitachi America, Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,17 +56,18 @@ function readVarInt(file: number, position: number | null): [number, number] {
     const buf = Buffer.alloc(1);
     let numByte = 0;
 
+    // eslint-disable-next-line no-constant-condition
     while (true) {
         if (readSync(file, buf, 0, 1, position) !== 1) {
             throw new BCVerifierError("Cannot read varint from a block file");
         }
         value = buf.readUInt8(0);
 
-        // tslint:disable-next-line: no-bitwise
+        // eslint-disable-next-line no-bitwise
         ret |= (value & 0x7f) << (7 * numByte);
         numByte++;
 
-        // tslint:disable-next-line: no-bitwise
+        // eslint-disable-next-line no-bitwise
         if (!(value & 0x80)) {
             return [ret, numByte];
         }
@@ -107,6 +108,7 @@ export class FabricBlockSource implements BlockSource {
             let size = 0;
             let len = 0;
 
+            // eslint-disable-next-line no-constant-condition
             while (true) {
                 [size, len] = readVarInt(file, position);
                 if (size > 0) {

--- a/src/result-set.ts
+++ b/src/result-set.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Hitachi America, Ltd.
+ * Copyright 2018-2020 Hitachi America, Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -54,8 +54,7 @@ function evaluate(predicate: ResultPredicate, values: ResultOperand[]): boolean 
             }
             return true;
         case ResultPredicate.INVOKE:
-            const params = values.slice(1).map((op) => op.value);
-            return v.value(...params);
+            return v.value(...values.slice(1).map((op) => op.value));
     }
 }
 

--- a/src/samples/fabcar.ts
+++ b/src/samples/fabcar.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// tslint:disable:no-console
+/* eslint-disable no-console */
 
 import { AppTransaction, AppTransactionCheckLogic, CheckPlugin,
          FabricFunctionInfo, FabricTransaction, ResultSet } from "..";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,8 +28,8 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": true,                   /* Report errors on unused locals. */
-    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noUnusedLocals": false,                  /* Report errors on unused locals. */
+    "noUnusedParameters": false,              /* Report errors on unused parameters. */
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 


### PR DESCRIPTION
As tslint is deprecated, this patch replaces tslint with eslint and
typescript-eslint to lint the source files.

This also disables checks for unused variables and parameters in tsc
since they are also deprecated.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>