### PR TITLE
Compare multiple ledgers

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ It also shows that the signature header (certificate) for the transaction `b9f33
 
 The results for these checks are all "OK," which means that the integrity of the blockchain is verified.
 
+### Comparison of multiple ledgers
+
+When multiple ledgers are specified, bcverifier checks the hash value of each block in a ledger with the hash values of the block
+in the other ledgers.
+Currently, only the "fabric-block" plugin with the JSON configuration supports this feature.
+The first ledger file in the configuration is considered to be "preferred," and the other ledger files are used only in this check.
+
 ## Application Specific Check
 
 You can write application specific check programs that are called from BCVerifier.
@@ -248,6 +255,7 @@ For detail, please refer to [the application checker reference](docs/application
 
 ## TODO
 
+- Support for Hyperledger Fabric v2.3
 - Documents (API reference, Data specification)
 - Unit tests and integration tests
 - Support for more plugins and platforms

--- a/src/check/index.ts
+++ b/src/check/index.ts
@@ -35,3 +35,15 @@ export interface AppTransactionCheckLogic {
     probeTransactionCheck(tx: AppTransaction): Promise<boolean>;
     performTransactionCheck(tx: AppTransaction, resultSet: ResultSet): Promise<void>;
 }
+
+export abstract class MultipleLedgerCheckPlugin {
+    protected preferredBlockProvider: BlockProvider;
+    protected otherProviders: BlockProvider[];
+    protected resultSet: ResultSet;
+
+    public constructor(preferredBlockProvider: BlockProvider, otherProviders: BlockProvider[], resultSet: ResultSet) {
+        this.preferredBlockProvider = preferredBlockProvider;
+        this.otherProviders = otherProviders;
+        this.resultSet = resultSet;
+    }
+}

--- a/src/check/multiple-ledgers.test.ts
+++ b/src/check/multiple-ledgers.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Hitachi America, Ltd.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import GenericMultipleLedgerBlockPlugin from "./multiple-ledgers";
+
+import { correctBlocks, MockBlock, MockSource } from "../mock/mock-block";
+import { BlockProvider } from "../provider";
+import { ResultSet } from "../result-set";
+import { ResultCode, ResultPredicate } from "../common";
+
+test("correct ledgers", async () => {
+    const preferredProvider = new BlockProvider(new MockSource("mock1", "mock-org1", correctBlocks));
+    const otherProviders = [new BlockProvider(new MockSource("mock2", "mock-org2", correctBlocks))];
+
+    const resultSet = new ResultSet();
+    const checker = new GenericMultipleLedgerBlockPlugin(preferredProvider, otherProviders, resultSet);
+
+    for (let i = 0; i < correctBlocks.length; i++) {
+        await checker.performCheck(i);
+    }
+
+    const blockResults = resultSet.getBlockResults();
+    for (let i = 0; i < correctBlocks.length; i++) {
+        const blockResult = blockResults[i];
+
+        expect(blockResult).toBeDefined();
+        expect(blockResult.number).toBe(i);
+
+        expect(blockResult.results).toHaveLength(1);
+        expect(blockResult.results[0].checkerID).toBe("GenericMultipleLedgerBlockPlugin.blockHashComparisonWithOtherSource");
+
+        const checkResult = blockResult.results[0];
+        expect(checkResult.result).toBe(ResultCode.OK);
+        if (checkResult.result === ResultCode.OK) {
+            expect(checkResult.predicate).toBe(ResultPredicate.EQBIN);
+            expect(checkResult.operands[0].name).toBe("mock1." + correctBlocks[i] + ".Hash");
+            expect(checkResult.operands[0].value).toEqual(correctBlocks[i].getHashValue());
+            expect(checkResult.operands[1].name).toBe("mock2." + correctBlocks[i] + ".Hash");
+            expect(checkResult.operands[1].value).toEqual(correctBlocks[i].getHashValue());
+        }
+    }
+});
+
+export const incorrectBlocks = [
+    new MockBlock(0, Buffer.from("NNNN"), Buffer.from(""), Buffer.from("NNNN"), Buffer.from("PABCD"),
+                  [ { id: "Tx1", type: 1 }, { id: "Tx2", type: 2 }]),
+    new MockBlock(1, Buffer.from("EFGH"), Buffer.from("PABCD"), Buffer.from("EFGH"), Buffer.from("PABCD"),
+                  [ { id: "Tx3", type: 3 }, { id: "Tx4", type: 1 }])
+];
+
+test("incorrect ledgers", async () => {
+    const preferredProvider = new BlockProvider(new MockSource("mock1", "mock-org1", correctBlocks));
+    const otherProviders = [new BlockProvider(new MockSource("mock2", "mock-org2", incorrectBlocks))];
+
+    const resultSet = new ResultSet();
+    const checker = new GenericMultipleLedgerBlockPlugin(preferredProvider, otherProviders, resultSet);
+
+    for (let i = 0; i < correctBlocks.length; i++) {
+        await checker.performCheck(i);
+    }
+
+    const blockResults = resultSet.getBlockResults();
+    for (let i = 0; i < correctBlocks.length; i++) {
+        const blockResult = blockResults[i];
+
+        expect(blockResult).toBeDefined();
+        expect(blockResult.number).toBe(i);
+
+        expect(blockResult.results).toHaveLength(1);
+        expect(blockResult.results[0].checkerID).toBe("GenericMultipleLedgerBlockPlugin.blockHashComparisonWithOtherSource");
+
+        const checkResult = blockResult.results[0];
+        expect(checkResult.result).toBe(ResultCode.ERROR);
+        if (checkResult.result === ResultCode.ERROR) {
+            expect(checkResult.predicate).toBe(ResultPredicate.EQBIN);
+            expect(checkResult.operands[0].name).toBe("mock1." + correctBlocks[i] + ".Hash");
+            expect(checkResult.operands[0].value).toEqual(correctBlocks[i].getHashValue());
+            expect(checkResult.operands[1].name).toBe("mock2." + correctBlocks[i] + ".Hash");
+            expect(checkResult.operands[1].value).toEqual(incorrectBlocks[i].getHashValue());
+        }
+    }
+});
+
+test("correct but inbalance ledgers", async () => {
+    const preferredProvider = new BlockProvider(new MockSource("mock1", "mock-org1", correctBlocks));
+    const otherProviders = [new BlockProvider(new MockSource("mock2", "mock-org2", correctBlocks.slice(0, 1)))];
+
+    const resultSet = new ResultSet();
+    const checker = new GenericMultipleLedgerBlockPlugin(preferredProvider, otherProviders, resultSet);
+
+    for (let i = 0; i < correctBlocks.length; i++) {
+        await checker.performCheck(i);
+    }
+
+    const blockResults = resultSet.getBlockResults();
+    for (let i = 0; i < correctBlocks.length; i++) {
+        const blockResult = blockResults[i];
+
+        if (i === 0) {
+            expect(blockResult).toBeDefined();
+            expect(blockResult.number).toBe(i);
+            expect(blockResult.results).toHaveLength(1);
+            expect(blockResult.results[0].checkerID).toBe("GenericMultipleLedgerBlockPlugin.blockHashComparisonWithOtherSource");
+
+            const checkResult = blockResult.results[0];
+            expect(checkResult.result).toBe(ResultCode.OK);
+            if (checkResult.result === ResultCode.OK) {
+                expect(checkResult.predicate).toBe(ResultPredicate.EQBIN);
+                expect(checkResult.operands[0].name).toBe("mock1." + correctBlocks[i] + ".Hash");
+                expect(checkResult.operands[0].value).toEqual(correctBlocks[i].getHashValue());
+                expect(checkResult.operands[1].name).toBe("mock2." + correctBlocks[i] + ".Hash");
+                expect(checkResult.operands[1].value).toEqual(correctBlocks[i].getHashValue());
+            }
+        } else {
+            expect(blockResult).toBeUndefined();
+        }
+    }
+});

--- a/src/check/multiple-ledgers.ts
+++ b/src/check/multiple-ledgers.ts
@@ -1,0 +1,47 @@
+/*
+ * Generic block checker plugin comparing with multiple ledgers
+ *
+ * Copyright 2021 Hitachi America, Ltd.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BlockCheckPlugin, MultipleLedgerCheckPlugin } from ".";
+import { ResultPredicate } from "../common";
+import { BlockProvider } from "../provider";
+import { BlockResultPusher, ResultSet } from "../result-set";
+
+export default class GenericMultipleLedgerBlockPlugin extends MultipleLedgerCheckPlugin implements BlockCheckPlugin {
+    public readonly checkerName = "GenericMultipleLedgerBlockPlugin";
+    public results: BlockResultPusher;
+
+    public constructor(preferredBlockProvider: BlockProvider, otherProviders: BlockProvider[], resultSet: ResultSet) {
+        super(preferredBlockProvider, otherProviders, resultSet);
+
+        this.results = new BlockResultPusher(this.checkerName, resultSet);
+    }
+
+    public async performCheck(blockNumber: number): Promise<void> {
+        const baseBlock = await this.preferredBlockProvider.getBlock(blockNumber);
+        const baseSourceId = this.preferredBlockProvider.getSourceID();
+
+        this.results.setBlock(baseBlock);
+
+        for (const provider of this.otherProviders) {
+            try {
+                const block = await provider.getBlock(blockNumber);
+
+                this.results.addResult("blockHashComparisonWithOtherSource", ResultPredicate.EQBIN,
+                    {
+                        name: `${baseSourceId}.${baseBlock}.Hash`,
+                        value: baseBlock.getHashValue()
+                    }, {
+                        name: `${provider.getSourceID()}.${block}.Hash`,
+                        value: block.getHashValue()
+                    });
+            } catch (e) {
+                // Ignore error because some source might not have some block
+            }
+        }
+    }
+}

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -22,6 +22,7 @@ describe("BlockProvider", () => {
 
     test("Good path", async () => {
         const provider = new BlockProvider(blockSource);
+        expect(provider.getSourceID()).toBe("mockSource");
 
         await expect(provider.getBlock(1)).resolves.toBe(correctBlocks[1]);
         await expect(provider.getBlock(0)).resolves.toBe(correctBlocks[0]);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -88,6 +88,10 @@ export class BlockProvider {
         }
     }
 
+    public getSourceID(): string {
+        return this.source.getSourceID();
+    }
+
     protected registerTransactions(block: Block): void {
         const txs = block.getTransactions();
         for (const tx of txs) {


### PR DESCRIPTION
This PR introduces a new feature that compares the hash values of blocks in one ledger with those in the other ledgers in the same network.

Currently the feature is supported only by the "fabric-block" plugin. When multiple ledger files are specified, it automatically compares the hash value of every block in the first ledger file with the other files.