### PR TITLE
fabric: Fix error in config transactions in v2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,11 @@ For detail, please refer to [the application checker reference](docs/application
 
 ## Changes
 
+### v0.3.0 (Feb. 25, 2021)
+
+- Fix an error when verifying Hyperledger Fabric v2.3 blocks
+- Add a check that compares the hash values of each block in multiple ledgers
+
 ### v0.2.2 (Oct. 8, 2020)
 
 - Add "fabric-query2" plugin to support querying blocks from v2.x peers

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The goal of this tool is to verify the integrity of blockchain blocks and transa
 ## Supported Blockchain Platforms
 
 - Hyperledger Fabric v1.4
-- Hyperledger Fabric v2.2
+- Hyperledger Fabric v2.2 & v2.3
 
 ## Prerequisites
 
@@ -255,7 +255,6 @@ For detail, please refer to [the application checker reference](docs/application
 
 ## TODO
 
-- Support for Hyperledger Fabric v2.3
 - Documents (API reference, Data specification)
 - Unit tests and integration tests
 - Support for more plugins and platforms

--- a/src/check/fabric-transaction-check.ts
+++ b/src/check/fabric-transaction-check.ts
@@ -79,6 +79,11 @@ export default class FabricTransactionIntegrityChecker implements TransactionChe
         const lastConfigBlock = metadataLastConfig == null ? 0 : metadataLastConfig;
         const configInfo = await this.config.getConfig(lastConfigBlock);
 
+        if ((transaction.header.signature_header.creator.id_bytes as Buffer).byteLength === 0) {
+            this.results.addSkipResult("performCheck", "No creator information");
+            return;
+        }
+
         if (transaction.getTransactionType() === 1 || transaction.getTransactionType() === 2) {
             this.results.addResult("performCheck",
                 ResultPredicate.INVOKE,


### PR DESCRIPTION
This patch fixes an error which may occur in checking Hyperledger Fabric v2.3 blocks because the genesis block might not have a creator identity in the header of its transaction. This also releases v0.3.0.