### PR TITLE
fabric-query2: Supports multiple ledgers

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The results for these checks are all "OK," which means that the integrity of the
 
 When multiple ledgers are specified, bcverifier checks the hash value of each block in a ledger with the hash values of the block
 in the other ledgers.
-Currently, only the "fabric-block" plugin with the JSON configuration supports this feature.
+Currently, the "fabric-block" and "fabric-query2" plugins support this feature.
 The first ledger file in the configuration is considered to be "preferred," and the other ledger files are used only in this check.
 
 ## Application Specific Check

--- a/test/fabric-query2/config.multiple.json
+++ b/test/fabric-query2/config.multiple.json
@@ -1,0 +1,27 @@
+{
+    "peers": [
+        {
+            "url": "grpcs://localhost:7051",
+            "mspID": "org1",
+            "tlsCACertFile": "test/fabric-query2/org1-ca-tls.pem"
+        },
+        {
+            "url": "grpcs://localhost:8051",
+            "mspID": "org2",
+            "tlsCACertFile": "test/fabric-query2/org2-ca-tls.pem"
+        }
+    ],
+    "channel": "test-channel",
+    "client": {
+        "certFile": "test/fabric-query2/user-cert.pem",
+        "keyFile": "test/fabric-query2/user-key.pem",
+        "mspID": "user-org",
+        "mutualTLS": {
+            "certFile": "test/fabric-query2/tls-user-cert.pem",
+            "keyFile": "test/fabric-query2/tls-user-key.pem"
+        }
+    },
+    "config": {
+        "useDiscovery": false
+    }
+}

--- a/test/fabric-query2/config.none.json
+++ b/test/fabric-query2/config.none.json
@@ -1,0 +1,15 @@
+{
+    "channel": "test-channel",
+    "client": {
+        "certFile": "test/fabric-query2/user-cert.pem",
+        "keyFile": "test/fabric-query2/user-key.pem",
+        "mspID": "user-org",
+        "mutualTLS": {
+            "certFile": "test/fabric-query2/tls-user-cert.pem",
+            "keyFile": "test/fabric-query2/tls-user-key.pem"
+        }
+    },
+    "config": {
+        "useDiscovery": false
+    }
+}

--- a/test/fabric-query2/org2-ca-tls.pem
+++ b/test/fabric-query2/org2-ca-tls.pem
@@ -1,0 +1,1 @@
+org2-ca-tls.pem


### PR DESCRIPTION
This patch enables the fabric-query2 plugin to have multiple block
sources, i.e. peers, so that it can perform comparison of hash values
among them.

Signed-off-by: Taku Shimosawa <taku.shimosawa.uf@hitachi.com>