### PR TITLE
New option to exclude checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,14 +241,25 @@ The results for these checks are all "OK," which means that the integrity of the
 
 ### Comparison of multiple ledgers
 
-When multiple ledgers are specified, bcverifier checks the hash value of each block in a ledger with the hash values of the block
+When multiple ledgers are specified, Blockchain Verifier checks the hash value of each block in a ledger with the hash values of the block
 in the other ledgers.
 Currently, the "fabric-block" and "fabric-query2" plugins support this feature.
-The first ledger file in the configuration is considered to be "preferred," and the other ledger files are used only in this check.
+The first ledger in the configuration is considered to be "preferred," and the other ledgers are used only in this check.
+
+## Platform Checkers
+
+Blockchain Verifier has several checkers to perform platform-level checks, independent of applications, as described in the table below.
+
+| Checker name         | Target platform    | Checks to be performed                                                 |
+|----------------------|--------------------|------------------------------------------------------------------------|
+| `generic-block`      | (Generic)          | The hash values of the blocks                                          |
+| `fabric-block`       | Hyperledger Fabric | The signature in the metadata of the blocks                            |
+| `fabric-transaction` | Hyperledger Fabric | The signature in the transactions, the hash values of the private data |
+| `multiple-ledgers`   | (Generic)          | The hash values of the blocks from different nodes                     |
 
 ## Application Specific Check
 
-You can write application specific check programs that are called from BCVerifier.
+You can write application specific check programs that are called from Blockchain Verifier.
 The check program should export a class that implements `AppStateCheckLogic` and/or `AppTransactionCheckLogic`
 (as defined in `check/index.ts`)
 
@@ -257,9 +268,8 @@ For detail, please refer to [the application checker reference](docs/application
 ## TODO
 
 - Documents (API reference, Data specification)
-- Unit tests and integration tests
+- Unit tests
 - Support for more plugins and platforms
-  - Multiple ledger files for Hyperledger Fabric
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Run with `-h` for the full list of the options.
 | `-c (config)`   | Configuration passed to the network plugin. See the description for the network plugins for detail |
 | `-o (file)`     | Save the result JSON in the specified file                                                         |
 | `-k (checkers)` | Specify the modules to use as application-specific checkers                                        |
+| `-x (checkers)` | Disable the checkers with specified names                                                          |
 
 ### Commands
 

--- a/src/bcverifier.ts
+++ b/src/bcverifier.ts
@@ -73,13 +73,17 @@ export class BCVerifier {
 
         const blockCheckPlugins: BlockCheckPlugin[] = [];
         for (const info of blockVerifiers) {
-            const verifierModule = await import(info.moduleName);
-            blockCheckPlugins.push(new verifierModule.default(blockProvider, this.resultSet));
+            if (!this.config.checkersToExclude.includes(info.pluginName)) {
+                const verifierModule = await import(info.moduleName);
+                blockCheckPlugins.push(new verifierModule.default(blockProvider, this.resultSet));
+            }
         }
         const txCheckPlugins: TransactionCheckPlugin[] = [];
         for (const info of txVerifiers) {
-            const verifierModule = await import(info.moduleName);
-            txCheckPlugins.push(new verifierModule.default(blockProvider, this.resultSet));
+            if (!this.config.checkersToExclude.includes(info.pluginName)) {
+                const verifierModule = await import(info.moduleName);
+                txCheckPlugins.push(new verifierModule.default(blockProvider, this.resultSet));
+            }
         }
 
         const preferredProvider = blockProvider;
@@ -96,8 +100,10 @@ export class BCVerifier {
 
         const multipleBlockCheckPlugins: BlockCheckPlugin[] = [];
         for (const info of multipleLedgerVerifiers) {
-            const verifierModule = await import(info.moduleName);
-            multipleBlockCheckPlugins.push(new verifierModule.default(preferredProvider, otherProviders, this.resultSet));
+            if (!this.config.checkersToExclude.includes(info.pluginName)) {
+                const verifierModule = await import(info.moduleName);
+                multipleBlockCheckPlugins.push(new verifierModule.default(preferredProvider, otherProviders, this.resultSet));
+            }
         }
 
         const appStateCheckers: AppStateCheckLogic[] = [];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ commander.version("v0.3.0")
     .option("-c, --network-config <config>", "Config for network")
     .option("-o, --output <result file>", "Result file")
     .option("-k, --checkers <checkers>", "Checker module list", list)
+    .option("-x, --exclude-checkers <checkers>", "Name of checkers to exclude", list)
     .arguments("<command>")
     .action((command) => {
         cliCommand = command;
@@ -68,11 +69,16 @@ async function start(): Promise<number> {
     if (opts.checkers != null) {
         applicationCheckers = opts.checkers;
     }
+    let checkersToExclude = [];
+    if (opts.excludeCheckers != null) {
+        checkersToExclude = opts.excludeCheckers;
+    }
 
     const bcv = new BCVerifier({
         networkType: opts.networkType,
         networkConfig: opts.networkConfig,
-        applicationCheckers: applicationCheckers
+        applicationCheckers: applicationCheckers,
+        checkersToExclude: checkersToExclude
     });
 
     const resultSet = await bcv.verify();

--- a/src/common.ts
+++ b/src/common.ts
@@ -9,6 +9,7 @@ export interface VerificationConfig {
     networkConfig: string;
 
     applicationCheckers: string[];
+    checkersToExclude: string[];
 }
 
 export enum ResultCode {


### PR DESCRIPTION
This PR introduces a new option in CLI to specify the checkers to exclude from executing.
This might be helpful when one wants to skip certain time-consuming checks.