### PR TITLE
Skip processing key-value pairs unless necessary

### DIFF
--- a/integration/basic-fabric.test.ts
+++ b/integration/basic-fabric.test.ts
@@ -35,8 +35,8 @@ const execOptions: ExecFileSyncOptionsWithBufferEncoding = {
     encoding: "utf8"
 };
 const versionCombinations: {[version: string]: string[]} = {
-    "2.2.3": ["2.2.3", "1.5.0"],
-    "2.3.2": ["2.3.2", "1.5.0"]
+    "2.2.3": ["2.2.3", "1.5.1"],
+    "2.3.2": ["2.3.2", "1.5.1"]
 };
 
 const FABRIC_LEDGER_PATH = ["ledgersData", "chains", "chains"];

--- a/src/bcverifier.ts
+++ b/src/bcverifier.ts
@@ -60,9 +60,11 @@ export class BCVerifier {
             throw new BCVerifierError("Failed to initialize network plugin");
         }
 
+        const appCheck = this.config.applicationCheckers.length > 0;
+
         const blockSource = await this.network.getPreferredBlockSource();
         let blockProvider: BlockProvider;
-        if (this.network.getDataModelType() === DataModelType.KeyValue) {
+        if (appCheck === true && this.network.getDataModelType() === DataModelType.KeyValue) {
             blockProvider = new KeyValueBlockProvider(blockSource);
         } else {
             blockProvider = new BlockProvider(blockSource);
@@ -91,7 +93,7 @@ export class BCVerifier {
         const dataModelType = this.network.getDataModelType();
         const otherProviders = allSources.filter((s) => s.getSourceID() !== preferredProvider.getSourceID())
             .map((s) => {
-                if (dataModelType === DataModelType.KeyValue) {
+                if (appCheck === true && dataModelType === DataModelType.KeyValue) {
                     return new KeyValueBlockProvider(s);
                 } else {
                     return new BlockProvider(s);
@@ -143,7 +145,7 @@ export class BCVerifier {
             }
         }
 
-        if (lastTx != null && this.network.getDataModelType() === DataModelType.KeyValue) {
+        if (lastTx != null && appCheck && this.network.getDataModelType() === DataModelType.KeyValue) {
             const kvProvider = blockProvider as KeyValueBlockProvider;
             const lastKeyValueTx = lastTx as KeyValueTransaction;
             try {

--- a/src/check/multiple-ledgers.test.ts
+++ b/src/check/multiple-ledgers.test.ts
@@ -84,7 +84,7 @@ test("incorrect ledgers", async () => {
     }
 });
 
-test("correct but inbalance ledgers", async () => {
+test("correct but imbalance ledgers", async () => {
     const preferredProvider = new BlockProvider(new MockSource("mock1", "mock-org1", correctBlocks));
     const otherProviders = [new BlockProvider(new MockSource("mock2", "mock-org2", correctBlocks.slice(0, 1)))];
 

--- a/src/network/fabric-query2.test.ts
+++ b/src/network/fabric-query2.test.ts
@@ -39,6 +39,7 @@ const newEndpoint = jest.fn().mockImplementation(() => new Endpoint({}));
 
 describe("FabricQuery2Source", () => {
     const config: FabricQuery2PluginConfig = JSON.parse(fs.readFileSync(configFile).toString());
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const peerConfig = config.peer!;
 
     describe("constructor", () => {


### PR DESCRIPTION
In the current implementation, key-value processing can take much time and memory to save the history of all the values in the state. This patch skips key-value pairs when no application checkers are specified.

This suppresses time and memory consumption when a user does not intend to examine and verify the contents of the transactions.