### PR TITLE
Add the "-b" option to limit the number of blocks to check

### DIFF
--- a/src/bcverifier.ts
+++ b/src/bcverifier.ts
@@ -111,6 +111,11 @@ export class BCVerifier {
                 lastBlock = this.config.endBlock;
             }
         }
+        if (this.config.checkBlockCount != null && this.config.checkBlockCount > 0) {
+            if (lastBlock - firstBlock + 1 >= this.config.checkBlockCount) {
+                lastBlock = firstBlock + this.config.checkBlockCount - 1;
+            }
+        }
 
         await blockProvider.cacheBlockRange(firstBlock, lastBlock);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,7 +92,7 @@ async function start(): Promise<number> {
         checkersToExclude: checkersToExclude,
         saveCheckpoint: saveCheckpoint,
         checkpointToResume: resumeData,
-        endBlock: opts.endBlock,
+        endBlock: opts.endBlock == null ? undefined : parseInt(opts.endBlock),
         skipKeyValue: opts.skipKeyValue
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ program.version("v0.4.0")
     .option("-s, --save-checkpoint <checkpoint>", "Save checkpoint after checks")
     .option("-r, --resume-checkpoint <checkpoint>", "Resume checks from checkpoint")
     .option("-e, --end-block <end block>", "Stop the checks at the specified block (inclusive)")
+    .option("-b, --check-block-count <check block count>", "Maximum number of blocks to be checked")
     .option("-i, --skip-key-value", "Skip key value processing even if checkpoint is specified")
     .arguments("<command>")
     .action((command) => {
@@ -93,7 +94,8 @@ async function start(): Promise<number> {
         saveCheckpoint: saveCheckpoint,
         checkpointToResume: resumeData,
         endBlock: opts.endBlock == null ? undefined : parseInt(opts.endBlock),
-        skipKeyValue: opts.skipKeyValue
+        skipKeyValue: opts.skipKeyValue,
+        checkBlockCount: opts.checkBlockCount == null ? undefined : parseInt(opts.checkBlockCount)
     });
 
     const { resultSet, checkpointData } = await bcv.verify();

--- a/src/common.ts
+++ b/src/common.ts
@@ -19,6 +19,7 @@ export interface VerificationConfig {
     checkpointToResume?: BCVCheckpointData;
 
     endBlock?: number;
+    checkBlockCount?: number;
 }
 
 export interface VerificationResult {


### PR DESCRIPTION
This PR adds a new option "-b" to limit the number of blocks that are to be verified along with some bug fix and minor improvement.