### PR TITLE
Add HLF v2.4.0 to the target versions of the integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The goal of this tool is to verify the integrity of blockchain blocks and transa
 ## Supported Blockchain Platforms
 
 - Hyperledger Fabric v1.4
-- Hyperledger Fabric v2.2 & v2.3
+- Hyperledger Fabric v2.2, v2.3 & v2.4
 
 ## Prerequisites
 

--- a/integration/basic-fabric.test.ts
+++ b/integration/basic-fabric.test.ts
@@ -39,8 +39,8 @@ const execOptions: ExecFileSyncOptionsWithBufferEncoding = {
     encoding: "utf8"
 };
 const versionCombinations: {[version: string]: string[]} = {
-    "2.2.3": ["2.2.3", "1.5.1"],
-    "2.3.2": ["2.3.2", "1.5.1"]
+    "2.2.3": ["2.2.3", "1.5.2"],
+    "2.3.3": ["2.3.3", "1.5.2"]
 };
 
 const FABRIC_LEDGER_PATH = ["ledgersData", "chains", "chains"];
@@ -184,7 +184,7 @@ type TestConfig = {
 
 describe.each<TestConfig>([
     { version: "2.2.3", startNetwork: startNetworkV22 },
-    { version: "2.3.2", startNetwork: startNetworkV23 },
+    { version: "2.3.3", startNetwork: startNetworkV23 }
 ])("Hyperledger Fabric $version", ({version, startNetwork}) => {
 
     beforeAll(async () => {

--- a/integration/basic-fabric.test.ts
+++ b/integration/basic-fabric.test.ts
@@ -40,7 +40,8 @@ const execOptions: ExecFileSyncOptionsWithBufferEncoding = {
 };
 const versionCombinations: {[version: string]: string[]} = {
     "2.2.3": ["2.2.3", "1.5.2"],
-    "2.3.3": ["2.3.3", "1.5.2"]
+    "2.3.3": ["2.3.3", "1.5.2"],
+    "2.4.0": ["2.4.0", "1.5.2"]
 };
 
 const FABRIC_LEDGER_PATH = ["ledgersData", "chains", "chains"];
@@ -184,7 +185,8 @@ type TestConfig = {
 
 describe.each<TestConfig>([
     { version: "2.2.3", startNetwork: startNetworkV22 },
-    { version: "2.3.3", startNetwork: startNetworkV23 }
+    { version: "2.3.3", startNetwork: startNetworkV23 },
+    { version: "2.4.0", startNetwork: startNetworkV23 }
 ])("Hyperledger Fabric $version", ({version, startNetwork}) => {
 
     beforeAll(async () => {


### PR DESCRIPTION
This patch adds Hyperledger Fabric v2.4.0 to the target versions of the integration tests.