### PR TITLE
Experimental support for Hyperledger Fabric v2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ The goal of this tool is to verify the integrity of blockchain blocks and transa
 ## Supported Blockchain Platforms
 
 - Hyperledger Fabric v2.2 & v2.4
+- Hyperledger Fabric v2.5 (experimental, only tested with beta)
 
 ## Prerequisites
 
-- Node.js >= v10.15
+- Node.js >= v16
 
 ## Install
 
@@ -256,6 +257,7 @@ Please also notice that application checkers will not be able to obtain history 
 
 - Delete *fabric-query* plugin and eliminate support for Hyperledger Fabric v1.4
 - Drop support for Hyperledger Fabric v2.3
+- Add support for Hyperledger Fabric v2.5 (LTS)
 
 ### v0.4.0 (Sep. 9, 2022)
 

--- a/integration/basic-fabric.test.ts
+++ b/integration/basic-fabric.test.ts
@@ -40,7 +40,7 @@ const execOptions: ExecFileSyncOptionsWithStringEncoding = {
 };
 const versionCombinations: {[version: string]: string[]} = {
     "2.2": ["2.2.9", "1.5.5"],
-    "2.4": ["2.4.7", "1.5.5"],
+    "2.4": ["2.4.9", "1.5.5"],
     "2.5": ["2.5.0-beta", "1.5.5"]
 };
 

--- a/integration/basic-fabric.test.ts
+++ b/integration/basic-fabric.test.ts
@@ -40,7 +40,8 @@ const execOptions: ExecFileSyncOptionsWithStringEncoding = {
 };
 const versionCombinations: {[version: string]: string[]} = {
     "2.2": ["2.2.9", "1.5.5"],
-    "2.4": ["2.4.7", "1.5.5"]
+    "2.4": ["2.4.7", "1.5.5"],
+    "2.5": ["2.5.0-beta", "1.5.5"]
 };
 
 const FABRIC_LEDGER_PATH = ["ledgersData", "chains", "chains"];
@@ -184,7 +185,8 @@ type TestConfig = {
 
 describe.each<TestConfig>([
     { version: "2.2", startNetwork: startNetworkV22 },
-    { version: "2.4", startNetwork: startNetworkV24 }
+    { version: "2.4", startNetwork: startNetworkV24 },
+    { version: "2.5", startNetwork: startNetworkV24 }
 ])("Hyperledger Fabric $version", ({version, startNetwork}) => {
 
     beforeAll(async () => {


### PR DESCRIPTION
This PR adds experimental support for Hyperledger Fabric v2.5 as it adds integration tests with v2.5.0-beta. It also upgrades the version of v2.4 used in the integration test to the latest.